### PR TITLE
cla: require actions:write

### DIFF
--- a/.github/workflows/cla-self.yaml
+++ b/.github/workflows/cla-self.yaml
@@ -12,6 +12,7 @@ jobs:
   cla:
     uses: Shopify/github-workflows/.github/workflows/cla.yaml@main
     permissions:
+      actions: write
       pull-requests: write
     secrets:
       token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -26,7 +26,8 @@ jobs:
       )
       || (github.event.pull_request && !github.event.pull_request.merged)
     permissions:
-      pull-requests: write
+      actions: write # to re-trigger workflows
+      pull-requests: write # to add/remove labels
     steps:
       - uses: Shopify/shopify-cla-action@1c5e9e39b803e4ed56c61a2f4bfd7a594c87c1f0 # v1.7.0
         with:


### PR DESCRIPTION
Per Evan on slack, this permission is required because the action wants to retrigger a workflow.
