### PR TITLE
dependabot-automerge: GITHUB_TOKEN via secret input

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -38,6 +38,11 @@ on:
         default: none
         description: |
           NPM upgrades to automatically merge. Valid values are: all, none, major, minor, patch.
+    secrets:
+      token:
+        required: true
+        default: ${{ secrets.GITHUB_TOKEN }}
+        description: GitHub token
 
 permissions: {}
 
@@ -79,7 +84,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.token }}
 
       - name: Merge GitHub Actions update
         if: |
@@ -103,7 +108,7 @@ jobs:
             )
           )
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
           MERGE_ALL: ${{ inputs.all }}
           MERGE_ECOSYSTEM: ${{ inputs.actions }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
@@ -134,7 +139,7 @@ jobs:
             )
           )
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
           MERGE_ALL: ${{ inputs.all }}
           MERGE_ECOSYSTEM: ${{ inputs.npm }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
@@ -165,7 +170,7 @@ jobs:
             )
           )
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
           MERGE_ALL: ${{ inputs.all }}
           MERGE_ECOSYSTEM: ${{ inputs.gomod }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -41,8 +41,7 @@ on:
     secrets:
       token:
         required: true
-        default: ${{ secrets.GITHUB_TOKEN }}
-        description: GitHub token
+        description: GitHub token - probably secrets.GITHUB_TOKEN
 
 permissions: {}
 


### PR DESCRIPTION
The previous implementation assumed the approval and merge event would be triggered by `github-actions[bot]`. We found that to be incompatible with branch protection settings, so we'd like to provide a custom token that will use a different actor.

To do that, accept a "secret" input for the token and prefer that to the built-in `secrets.GITHUB_TOKEN`. Callers can provide that token as an argument: `with: secrets: ${{secrets.GITHUB_TOKEN}}`, or a token of their choosing.

⚠️ This is a breaking change. We can't default this to `secrets.GITHUB_TOKEN` for the user. We could maybe hack something where we "select" between `${{secrets.token}}` and `${{secrets.GITHUB_TOKEN}}` in a bash step. This PR is lazy and expects all users to add:
```yaml
    uses: Shopify/github-workflows/.github/workflows/dependabot-automerge.yaml@dependabot-automerge-token
    with:
      actions: patch
    secrets:
      token: ${{secrets.GITHUB_TOKEN}}
```



# Related
- https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets